### PR TITLE
Fix instance parameter

### DIFF
--- a/fakegir.py
+++ b/fakegir.py
@@ -77,8 +77,6 @@ def extract_methods(class_tag):
             method_name = element.attrib['name']
             docstring = get_docstring(element)
             params = get_parameters(element)
-            #if 'self' not in params:
-                #params.insert(0, 'self')
             methods_content += insert_function(method_name, params, 1,
                                                docstring)
     return methods_content


### PR DESCRIPTION
I used this tool to create import for gi.repository, enabling my PyCharm completion for GTK3.
I noticed the generated stubs was duplicating the _self_ parameter with the named one in the .git file, for example, this was generated for the builder class:

```
def add_from_file(self, builder, filename):
...
```

instead of:

```
def add_from_file(self, filename):
...
```

This pull request adds support for the `<instance-parameter>` tag present in the `.gir` files, but feel free to perform more tests on your binary packages as well, looks odd to me no one ever reported this :)

Thanks for your work!
