### PR TITLE
Fix duplicate parameters (in some cases)

### DIFF
--- a/fakegir.py
+++ b/fakegir.py
@@ -34,7 +34,8 @@ def get_parameters(element):
                     if keyword.iskeyword(param_name):
                         param_name = "_" + param_name
 
-                    params.append(param_name)
+                    if not param_name in params:
+                        params.append(param_name)
                 except KeyError:
                     pass
     return params


### PR DESCRIPTION
This will avoid to add the same parameter names if they are declared so: this will happen sometimes when "instance-parameter" and "self" are declared in the same "parameters" element, such as `Gst-0.10.gir`:

```
  <instance-parameter name="object" transfer-ownership="none">
    <type name="Object" c:type="GstObject*"/>
  </instance-parameter>
  <parameter name="self" transfer-ownership="none">
    <doc xml:space="preserve">The XML node to load @object from</doc>
    <type name="libxml2.NodePtr" c:type="xmlNodePtr"/>
  </parameter>
```
