### PR TITLE
Check enum_name length

### DIFF
--- a/fakegir.py
+++ b/fakegir.py
@@ -4,7 +4,7 @@ import os
 import keyword
 from lxml import etree
 
-GIR_PATH = '/usr/share/gir-1.0/'
+GIR_PATHS = ['/usr/share/gir-1.0/']
 FAKEGIR_PATH = os.path.expanduser('~/.cache/fakegir')
 XMLNS = "http://www.gtk.org/introspection/core/1.0"
 
@@ -198,14 +198,15 @@ def parse_gir(gir_path):
 
 def iter_girs():
     """Return a generator of all available gir files"""
-    for gir_file in os.listdir(GIR_PATH):
-        # Don't know what to do with those, guess nobody uses PyGObject
-        # for Gtk 2.0 anyway
-        if gir_file in ('Gtk-2.0.gir', 'Gdk-2.0.gir', 'GdkX11-2.0.gir'):
-            continue
-        module_name = gir_file[:gir_file.index('-')]
-        gir_info = (module_name, gir_file)
-        yield gir_info
+    for gir_path in GIR_PATHS:
+        for gir_file in os.listdir(gir_path):
+            # Don't know what to do with those, guess nobody uses PyGObject
+            # for Gtk 2.0 anyway
+            if gir_file in ('Gtk-2.0.gir', 'Gdk-2.0.gir', 'GdkX11-2.0.gir'):
+                continue
+            module_name = gir_file[:gir_file.index('-')]
+            gir_info = (module_name, gir_file, gir_path)
+            yield gir_info
 
 
 def generate_fakegir():
@@ -221,8 +222,8 @@ def generate_fakegir():
     with open(repo_init_path, 'w') as repo_init_file:
         repo_init_file.write('')
 
-    for module_name, gir_file in iter_girs():
-        gir_path = os.path.join(GIR_PATH, gir_file)
+    for module_name, gir_file, gir_path in iter_girs():
+        gir_path = os.path.join(gir_path, gir_file)
         fakegir_content = parse_gir(gir_path)
         fakegir_path = os.path.join(FAKEGIR_PATH, 'gi/repository',
                                     module_name + ".py")

--- a/fakegir.py
+++ b/fakegir.py
@@ -85,7 +85,7 @@ def insert_enum(element):
     members = element.findall("{%s}member" % XMLNS)
     for member in members:
         enum_name = member.attrib['name']
-        if enum_name[0].isdigit():
+        if len(enum_name) and enum_name[0].isdigit():
             enum_name = '_' + enum_name
         enum_value = member.attrib['value']
         enum_value = enum_value.replace('\\', '\\\\')


### PR DESCRIPTION
Without this check enum_name[0] throws an error.

```
...
Parsing /usr/share/gir-1.0/Cogl-2.0.gir
Traceback (most recent call last):
  File "fakegir.py", line 234, in <module>
    generate_fakegir()
  File "fakegir.py", line 226, in generate_fakegir
    fakegir_content = parse_gir(gir_path)
  File "fakegir.py", line 195, in parse_gir
    namespace_content = extract_namespace(namespace)
  File "fakegir.py", line 165, in extract_namespace
    namespace_content += insert_enum(element)
  File "fakegir.py", line 88, in insert_enum
    if enum_name[0].isdigit():
IndexError: string index out of range
```