### PR TITLE
build-jedi-cache.sh now actually builds something

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,16 @@ witnessed this script actually  working with the current version of Jedi but
 I'll leave it here in case someone manages to get something out of it. (Please
 make a Pull Request if you do).
 
-Also it's worth mentioning that `build-jedi-cache.sh` requires docopt module to
-run. On Debian/Ubuntu it is located in `python-docopt` and `python3-docopt`
-packages for Python 2 and Python 3, respectively.
+Also it's worth mentioning that:
+
+  * `build-jedi-cache.sh` requires docopt module to run. On Debian/Ubuntu
+    it is located in `python-docopt` and `python3-docopt` packages for
+    Python 2 and Python 3, respectively.
+
+  * Python interpreter in `build-jedi-cache.sh` defaults to `python`,
+    which usually points to Python 2. Use `-3` CLI option to make the
+    script use `python3` instead, or `-p /path/to/python` to force
+    an absolute interpreter path.
 
 The other option which I use is to create a virtualenv and copy the fakegir
 gi package into it:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ witnessed this script actually  working with the current version of Jedi but
 I'll leave it here in case someone manages to get something out of it. (Please
 make a Pull Request if you do).
 
+Also it's worth mentioning that `build-jedi-cache.sh` requires docopt module to
+run. On Debian/Ubuntu it is located in `python-docopt` and `python3-docopt`
+packages for Python 2 and Python 3, respectively.
+
 The other option which I use is to create a virtualenv and copy the fakegir
 gi package into it:
 

--- a/build-jedi-cache.sh
+++ b/build-jedi-cache.sh
@@ -1,5 +1,49 @@
 #!/bin/bash
 
+PYTHON_EXECUTABLE=python
+
+_help() {
+    cat <<EOF
+Usage: $0 [options...]
+
+Options:
+    -3      Use python3 instead of python as a Python interpreter
+    -p INTERPRETER
+            Specify custom Python interpreter path
+    -h      Show this help message
+EOF
+}
+
+while getopts '3p:h' arg; do
+    case "$arg" in
+        3) PYTHON_EXECUTABLE=python3;;
+        p) PYTHON_EXECUTABLE="$OPTARG";;
+        h) _help; exit 0;;
+        *) _help >&2; exit 127;;
+    esac
+done
+
+shift $(( $OPTIND - 1 ))
+
+# if $PYTHON_EXECUTABLE does not contain slashes,
+# then use /usr/bin/env in shebang line
+# otherwise, try getting the absolute path and use it instead
+if [ "$(expr "$PYTHON_EXECUTABLE" : '.*/')" -eq 0 ]; then
+    # also, find the real 'env'
+    _env=
+    for _p in /bin/env /usr/bin/env; do
+        if [ -x "$_p" ]; then
+            _env=$_p
+            break
+        fi
+    done
+    [ "$_env" ] || { echo "Could not find 'env' executable" >&2; exit 4; }
+
+    SHEBANG="#!$_env $PYTHON_EXECUTABLE"
+else
+    SHEBANG="#!$(realpath "$PYTHON_EXECUTABLE")"
+fi
+
 VIM_PLUGINS_DIR="$HOME/.vim/bundle"
 if [ ! -d $VIM_PLUGINS_DIR ]; then
     VIM_PLUGINS_DIR="$HOME/.vim/plugged"
@@ -9,13 +53,25 @@ if [ ! -d $VIM_PLUGINS_DIR ]; then
     exit 2
 fi
 
-JEDI_PATH=$VIM_PLUGINS_DIR/YouCompleteMe/third_party/ycmd/third_party/jedi
+JEDI_PATH=
+
+for _p in \
+    $VIM_PLUGINS_DIR/YouCompleteMe/third_party/ycmd/third_party/jedi \
+    $VIM_PLUGINS_DIR/YouCompleteMe/third_party/ycmd/third_party/JediHTTP/vendor/jedi
+do
+    if [ -d "$_p" ]; then
+        JEDI_PATH=$_p
+        break
+    fi
+done
+
+[ "$JEDI_PATH" ] || { echo "Unable to find Jedi directory"; exit 3; }
 
 #python fakegir.py
 rm -rf $HOME/.cache/jedi
 
 pkgs=""
-echo '#/bin/env python' >/tmp/fakeprg.py
+echo "$SHEBANG" >/tmp/fakeprg.py
 for f in ~/.cache/fakegir/gi/repository/*.py; do
     pkgname=`basename $f | cut -d . -f 1`
     pkgs="$pkgs $pkgname"
@@ -33,5 +89,6 @@ for pkgname in $pkgs; do
 
     export PYTHONPATH=$HOME/.cache/fakegir
     pushd $JEDI_PATH
-    $JEDI_PATH/sith.py -f run completions /tmp/${pkgname}-fakeprg.py $fakeprg_lines $compl_col
+    $PYTHON_EXECUTABLE $JEDI_PATH/sith.py \
+        -f run completions /tmp/${pkgname}-fakeprg.py $fakeprg_lines $compl_col
 done


### PR DESCRIPTION
Creating a PR, just as requested :)

The script now works with the latest YCM+Jedi combo (autodetected) and Python 3 (with a CLI option, default is to use `python` executable which is most probably Python 2), but hopefully it is still compatible with both older YCM versions and Python 2.

Also, updated the documentation (my English may be a bit raw, sorry).