### PR TITLE
Work-around for issue #24: supply default for missing type names

### DIFF
--- a/fakegir.py
+++ b/fakegir.py
@@ -73,7 +73,11 @@ def get_parameter_type(element):
     for elem_property in element:
         tag = QName(elem_property)
         if tag.localname == "type":
-            param_type = elem_property.attrib['name']
+            try:
+                param_type = elem_property.attrib['name']
+            except KeyError:
+                param_type = 'object'
+
             break
     return param_type
 

--- a/fakegir.py
+++ b/fakegir.py
@@ -152,7 +152,13 @@ def get_returntype(element):
                 try:
                     subtag = QName(subelem)
                     if subtag.localname == "type":
-                        return (return_doc, subelem.attrib['name'])
+                        try:
+                            return_type = subelem.attrib['name']
+                        except KeyError:
+                            return_type = 'object'
+
+                        return (return_doc, return_type)
+
                 except KeyError:
                     pass
     return ("", "None")


### PR DESCRIPTION
The problem: If the type of a method argument or (probably) a return value of a method is not GObject-introspectable then the `<type>` tag for this type has no `name` attribute. The script fails in such cases.

This patch works around this issue (#24) by supplying a default `object` name if the `name` attribute is missing.