### PR TITLE
Support static methods

### DIFF
--- a/fakegir.py
+++ b/fakegir.py
@@ -216,18 +216,20 @@ def extract_methods(class_tag):
     methods_content = ''
     for element in class_tag:
         tag = QName(element)
-        if tag.localname in ('method', 'virtual-method'):
+        if tag.localname in ('function', 'method', 'virtual-method'):
             method_name = element.attrib['name']
             if method_name == 'print':
                 method_name += "_"
             docstring = get_docstring(element)
             params = get_parameters(element)
+            annotation = "" if any(p[0] == "self" for p in params) else "@staticmethod"
             returntype = get_returntype(element)
             methods_content += insert_function(method_name,
                                                params,
                                                returntype,
                                                1,
-                                               docstring)
+                                               docstring,
+                                               annotation)
     return methods_content
 
 


### PR DESCRIPTION
Some GObject classes have static methods, represented in .gir files with &lt;function&gt; tags, but these were missing from fakegir's output. I've changed `extract_methods()` to recognise &lt;function&gt; tags within &lt;class&gt;.

I'm not sure whether &lt;function&gt; and &lt;method&gt; tags are used exclusively for static and instance methods exclusively, so I've used the presence (or not) of a 'self' parameter to decide whether to add the `@staticmethod` annotation. It would probably be OK to check only the first parameter instead of using `any()` as I have done.