### PR TITLE
Do not quote constants of numeric or boolean type

### DIFF
--- a/fakegir.py
+++ b/fakegir.py
@@ -418,7 +418,7 @@ def extract_namespace(namespace):
 
                 if quote_string:
                     constant_value = constant_value.replace("\\", "\\\\")
-                    constant_value = r'r"""{}"""'.format(constant_value)
+                    constant_value = 'r"""{}"""'.format(constant_value)
 
             namespace_content += "{} = {}\n".format(constant_name, constant_value)
 

--- a/fakegir.py
+++ b/fakegir.py
@@ -416,9 +416,9 @@ def extract_namespace(namespace):
                             constant_value = constant_value.capitalize()
                             quote_string = False
 
-                    if quote_string:
-                        constant_value = constant_value.replace("\\", "\\\\")
-                        constant_value = r'r"""{}"""'.format(constant_value)
+                if quote_string:
+                    constant_value = constant_value.replace("\\", "\\\\")
+                    constant_value = r'r"""{}"""'.format(constant_value)
 
             namespace_content += "{} = {}\n".format(constant_name, constant_value)
 


### PR DESCRIPTION
Akin to #34 but for constants.
The content is checked for regexp match first to ensure that the actual value matches the type.