### PR TITLE
Select GTK version using environement variables

### DIFF
--- a/fakegir.py
+++ b/fakegir.py
@@ -21,6 +21,11 @@ if GIR_PATHS and len(GIR_PATHS):
 else:
     GIR_PATHS = ['/usr/share/gir-1.0']
 
+if ('GTK_VERSION' in os.environ):
+    GTK_VERSION = int(os.environ["GTK_VERSION"])
+else:
+    GTK_VERSION = 3
+
 GIR_TO_NATIVE_TYPEMAP = {
     'gboolean': 'bool',
     'gint': 'int',
@@ -419,12 +424,17 @@ def iter_girs():
         gir_files.extend(glob.glob(os.path.join(gir_path, '*.gir')))
 
     for gir_file in gir_files:
-        # Don't know what to do with those, guess nobody uses PyGObject
-        # for Gtk 2.0 anyway
         basename = os.path.basename(gir_file)
-        if basename in ('Gtk-2.0.gir', 'Gdk-2.0.gir', 'GdkX11-2.0.gir'):
+        
+        # Check which GTK Version the user wants to use
+        if basename in ('Gtk-2.0.gir', 'Gdk-2.0.gir', 'GdkX11-2.0.gir') and GTK_VERSION != 2:
             continue
 
+        if basename in ('Gtk-3.0.gir', 'Gdk-3.0.gir', 'GdkX11-3.0.gir') and GTK_VERSION != 3:
+            continue
+
+        if basename in ('Gtk-4.0.gir', 'Gdk-4.0.gir', 'GdkX11-4.0.gir') and GTK_VERSION != 4:
+            continue
         try:
             module_name = basename[:basename.index('-')]
 


### PR DESCRIPTION
Now that GTK4 is released the assumption that there is only one GTK version to generate stubs for doesn't work anymore.
I experienced this myself the hard way, because the GTK 3 stub files always got overwritten by the GTK 4 ones which are completely different and don't make sense when you want to use GTK3.

To solve this, I introduced another environment variable that let's the user select the GTK version he wants.
If no environment variable is set, the script generates stubfiles for GTK3 by default, because i think that's the most used right now.