### PR TITLE
Accept **kwargs if a class doesn't specify any constructor parameters

### DIFF
--- a/fakegir.py
+++ b/fakegir.py
@@ -293,6 +293,8 @@ def extract_constructors(class_tag):
             if method_name == "new":
                 params_init = list(params)
                 params_init.insert(0, ("self", "", ""))
+                if len(params) == 0:
+                    params_init.append(("**kwargs", "", ""))
                 methods_content += insert_function("__init__", params_init,
                                                    returntype, 1, docstring)
 


### PR DESCRIPTION
This is valid GTK (4) code: 

```
Gtk.Button(label="Hello, world!")
```

The gir files for the Gtk.Button class don't specify any argument for the constructor, so fakegir creates a `__init__(self)` function that doesn't accept any keyword argument.

This commit changes the default `__init__` function to accept `**kwargs` if the constructor doesn't specify any parameter. 